### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/InsecureWebApp/Controllers/PrescriptionController.cs
+++ b/InsecureWebApp/Controllers/PrescriptionController.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Text.RegularExpressions;
 
 namespace MicroFocus.InsecureWebApp.Controllers
 {
@@ -103,7 +104,7 @@ namespace MicroFocus.InsecureWebApp.Controllers
         public FileResult DownloadFile(string fileName)
         {
             //Build the File Path.
-            string path = Path.Combine(Directory.GetCurrentDirectory(), "Files"+ Path.DirectorySeparatorChar +"Prescriptions" + Path.DirectorySeparatorChar) + fileName;
+            string path = Path.Combine(Directory.GetCurrentDirectory(), "Files"+ Path.DirectorySeparatorChar +"Prescriptions" + Path.DirectorySeparatorChar) + Regex.Replace(Convert.ToString(fileName), "([/\\\\:*?\"<>|])|(^\\s)|([.\\s]$)", "_").Replace("\0", "");
 
             //Read the File data into Byte Array.
             byte[] bytes = System.IO.File.ReadAllBytes(path);


### PR DESCRIPTION
This change fixes a **critical severity** (🚨) **Path Traversal** issue reported by **Fortify**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/1380ed1d-d1d6-423f-87ce-207dd6924726/project/4ab9fd70-f0a7-4655-af42-3ee5c6f7b201/report/65f04f11-5f26-4e42-9754-22a7a9b69c05/fix/e5229491-5a67-4310-842a-ad72d2ab6731)
