### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/InsecureWebApp/Controllers/FileController.cs
+++ b/InsecureWebApp/Controllers/FileController.cs
@@ -4,6 +4,7 @@ using ICSharpCode.SharpZipLib.Tar;
 using System.IO;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
+using System;
 
 namespace MicroFocus.InsecureWebApp.Controllers
 {
@@ -18,7 +19,8 @@ namespace MicroFocus.InsecureWebApp.Controllers
         {
             string sPres_Location = "Files" + Path.DirectorySeparatorChar + "Prescriptions" + Path.DirectorySeparatorChar;
             string sDir = Path.Combine(Directory.GetCurrentDirectory(), sPres_Location);
-            string sPath = Path.Combine(Directory.GetCurrentDirectory(), targetDir) + Path.DirectorySeparatorChar +  zipFileName;
+            string basePath = Directory.GetCurrentDirectory();
+            string sPath = EnsurePathIsRelativeToDest(basePath, Path.Combine(basePath, targetDir)) + Path.DirectorySeparatorChar +  zipFileName;
             FastZip fastZip = new FastZip();
             string fileFilter = null;
             string sFinalDir = string.Empty;
@@ -42,6 +44,23 @@ namespace MicroFocus.InsecureWebApp.Controllers
 
             //Response.Headers.Add("Content-Disposition", "attachment; filename="+ zipFileName +".zip");
             //return new FileContentResult(JsonSerializer.SerializeToUtf8Bytes(zipFileName), "application/json");
+        }
+
+        public static string EnsurePathIsRelativeToDest(string basePath, string path)
+        {
+            // Normalize slashes in paths
+            string normalizedPath = Path.GetFullPath(Path.Combine(path.Split('/', '\\')));
+            string normalizedBasePath = Path.GetFullPath(Path.Combine(basePath.Split('/', '\\')));
+        
+            // Ensure and dir paths end with a slash
+            normalizedBasePath = normalizedBasePath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            normalizedPath = normalizedPath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        
+            if(!normalizedPath.StartsWith(normalizedBasePath))
+            {
+                throw new ArgumentException("Potential directory traversal attempt.");
+            }
+            return path;
         }
     }
 }


### PR DESCRIPTION
This change fixes a **critical severity** (🚨) **Path Traversal** issue reported by **Fortify**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/1380ed1d-d1d6-423f-87ce-207dd6924726/project/4ab9fd70-f0a7-4655-af42-3ee5c6f7b201/report/0d65215d-e3af-4d07-ba30-240deef64f3d/fix/958d2ecf-36e6-4688-ae27-1189c14712b2)
